### PR TITLE
Customizing invidivual highlight groups

### DIFF
--- a/autoload/pinkmare.vim
+++ b/autoload/pinkmare.vim
@@ -1,0 +1,58 @@
+function pinkmare#get_default_palette() " {{{
+    if &background ==# 'dark'
+        return {
+            \ 'bg0':        ['#202330',   '235',  'Black'],
+            \ 'bg1':        ['#472541',   '236',  'DarkGrey'],
+            \ 'bg2':        ['#242021',   '237',  'DarkGrey'],
+            \ 'bg3':        ['#242021',   '238',  'DarkGrey'],
+            \ 'bg4':        ['#2d2f42',   '239',  'Grey'],
+            \ 'bg_red':     ['#f2448b',   '52',   'DarkRed'],
+            \ 'bg_green':   ['#333b2f',   '22',   'DarkGreen'],
+            \ 'bg_blue':    ['#203a41',   '17',   'DarkBlue'],
+            \ 'fg':         ['#FAE8B6',   '223',  'White'],
+            \ 'red':        ['#FF38A2',   '167',  'Red'],
+            \ 'orange':     ['#ffb347',   '208',  'Red'],
+            \ 'yellow':     ['#ffc85b',   '214',  'Yellow'],
+            \ 'green':      ['#9cd162',   '108',  'Green'],
+            \ 'cyan':       ['#87c095',   '108',  'Cyan'],
+            \ 'blue':       ['#eba4ac',   '109',  'Blue'],
+            \ 'purple':     ['#d9bcef',   '175',  'Magenta'],
+            \ 'grey':       ['#444444',   '245',  'LightGrey'],
+            \ 'light_grey': ['#6D7A72',   '245',  'LightGrey'],
+            \ 'gold':       ['#fff0f5',   '214',  'Yellow'],
+            \ 'findme':     ['#4DB560',   '215',  'FindMe'],
+            \ 'none':       ['NONE',      'NONE', 'NONE']
+            \ }
+    elseif &background ==# 'light'
+        return {
+            \ 'bg0':        ['#202330',   '235',  'Black'],
+            \ 'bg1':        ['#472541',   '236',  'DarkGrey'],
+            \ 'bg2':        ['#242021',   '237',  'DarkGrey'],
+            \ 'bg3':        ['#242021',   '238',  'DarkGrey'],
+            \ 'bg4':        ['#2d2f42',   '239',  'Grey'],
+            \ 'bg_red':     ['#f2448b',   '52',   'DarkRed'],
+            \ 'bg_green':   ['#333b2f',   '22',   'DarkGreen'],
+            \ 'bg_blue':    ['#203a41',   '17',   'DarkBlue'],
+            \ 'fg':         ['#FAE8B6',   '223',  'White'],
+            \ 'red':        ['#FF38A2',   '167',  'Red'],
+            \ 'orange':     ['#ffb347',   '208',  'Red'],
+            \ 'yellow':     ['#ffc85b',   '214',  'Yellow'],
+            \ 'green':      ['#9cd162',   '108',  'Green'],
+            \ 'cyan':       ['#87c095',   '108',  'Cyan'],
+            \ 'blue':       ['#eba4ac',   '109',  'Blue'],
+            \ 'purple':     ['#d9bcef',   '175',  'Magenta'],
+            \ 'grey':       ['#444444',   '245',  'LightGrey'],
+            \ 'light_grey': ['#6D7A72',   '245',  'LightGrey'],
+            \ 'gold':       ['#fff0f5',   '214',  'Yellow'],
+            \ 'findme':     ['#4DB560',   '215',  'FindMe'],
+            \ 'none':       ['NONE',      'NONE', 'NONE']
+            \ }
+    endif
+endfunction " }}}
+
+function pinkmare#get_palette()
+    let l:config_palette = get(g:, 'pinkmare_palette', {})
+    return extend(pinkmare#get_default_palette(), l:config_palette)
+endfunction
+
+"vim: set sw=2 ts=2 sts=2 et tw=80 ft=vim fdm=marker fmr={{{,}}}:

--- a/colors/pinkmare.vim
+++ b/colors/pinkmare.vim
@@ -19,7 +19,6 @@ let g:colors_name = 'pinkmare'
 " }}}
 " Configuration: {{{
 let s:configuration = {}
-let s:configuration.palette = get(g:, 'pinkmare_palette', {})
 let s:configuration.overwrite_groups = get(g:, 'pinkmare_overwrite_groups', {})
 let s:configuration.transparent_background = get(g:, 'pinkmare_transparent_background', 0)
 let s:configuration.disable_italic_comment = get(g:, 'pinkmare_disable_italic_comment', 0)
@@ -30,61 +29,7 @@ let s:configuration.cursor = get(g:, 'pinkmare_cursor', 'auto')
 let s:configuration.current_word = get(g:, 'pinkmare_current_word', get(g:, 'pinkmare_transparent_background', 0) == 0 ? 'grey background' : 'bold')
 " }}}
 " Palette: {{{
-if &background ==# 'dark' 
-    let s:palette = {
-          \ 'bg0':        ['#202330',   '235',  'Black'],
-          \ 'bg1':        ['#472541',   '236',  'DarkGrey'],
-          \ 'bg2':        ['#242021',   '237',  'DarkGrey'],
-          \ 'bg3':        ['#242021',   '238',  'DarkGrey'],
-          \ 'bg4':        ['#2d2f42',   '239',  'Grey'],
-          \ 'bg_red':     ['#f2448b',   '52',   'DarkRed'],
-          \ 'bg_green':   ['#333b2f',   '22',   'DarkGreen'],
-          \ 'bg_blue':    ['#203a41',   '17',   'DarkBlue'],
-          \ 'fg':         ['#FAE8B6',   '223',  'White'],
-          \ 'red':        ['#FF38A2',   '167',  'Red'],
-          \ 'orange':     ['#ffb347',   '208',  'Red'],
-          \ 'yellow':     ['#ffc85b',   '214',  'Yellow'],
-          \ 'green':      ['#9cd162',   '108',  'Green'],
-          \ 'cyan':       ['#87c095',   '108',  'Cyan'],
-          \ 'blue':       ['#eba4ac',   '109',  'Blue'],
-          \ 'purple':     ['#d9bcef',   '175',  'Magenta'],
-          \ 'grey':       ['#444444',   '245',  'LightGrey'],
-          \ 'light_grey': ['#6D7A72',   '245',  'LightGrey'],
-          \ 'gold':       ['#fff0f5',   '214',  'Yellow'],
-          \ 'findme':     ['#4DB560',   '215',  'FindMe'],
-          \ 'none':       ['NONE',      'NONE', 'NONE']
-          \ }
-
-    call extend(s:palette, s:configuration.palette)
-endif
-
-if &background ==# 'light' 
-    let s:palette = {
-          \ 'bg0':        ['#202330',   '235',  'Black'],
-          \ 'bg1':        ['#472541',   '236',  'DarkGrey'],
-          \ 'bg2':        ['#242021',   '237',  'DarkGrey'],
-          \ 'bg3':        ['#242021',   '238',  'DarkGrey'],
-          \ 'bg4':        ['#2d2f42',   '239',  'Grey'],
-          \ 'bg_red':     ['#f2448b',   '52',   'DarkRed'],
-          \ 'bg_green':   ['#333b2f',   '22',   'DarkGreen'],
-          \ 'bg_blue':    ['#203a41',   '17',   'DarkBlue'],
-          \ 'fg':         ['#FAE8B6',   '223',  'White'],
-          \ 'red':        ['#FF38A2',   '167',  'Red'],
-          \ 'orange':     ['#ffb347',   '208',  'Red'],
-          \ 'yellow':     ['#ffc85b',   '214',  'Yellow'],
-          \ 'green':      ['#9cd162',   '108',  'Green'],
-          \ 'cyan':       ['#87c095',   '108',  'Cyan'],
-          \ 'blue':       ['#eba4ac',   '109',  'Blue'],
-          \ 'purple':     ['#d9bcef',   '175',  'Magenta'],
-          \ 'grey':       ['#444444',   '245',  'LightGrey'],
-          \ 'light_grey': ['#6D7A72',   '245',  'LightGrey'],
-          \ 'gold':       ['#fff0f5',   '214',  'Yellow'],
-          \ 'findme':     ['#4DB560',   '215',  'FindMe'],
-          \ 'none':       ['NONE',      'NONE', 'NONE']
-          \ }
-
-    call extend(s:palette, s:configuration.palette)
-endif
+let s:palette = pinkmare#get_palette()
 " }}}
 " Function: {{{
 " call s:HL(group, foreground, background)

--- a/colors/pinkmare.vim
+++ b/colors/pinkmare.vim
@@ -20,6 +20,7 @@ let g:colors_name = 'pinkmare'
 " Configuration: {{{
 let s:configuration = {}
 let s:configuration.palette = get(g:, 'pinkmare_palette', {})
+let s:configuration.overwrite_groups = get(g:, 'pinkmare_overwrite_groups', {})
 let s:configuration.transparent_background = get(g:, 'pinkmare_transparent_background', 0)
 let s:configuration.disable_italic_comment = get(g:, 'pinkmare_disable_italic_comment', 0)
 let s:configuration.enable_italic_string = get(g:, 'pinkmare_enable_italic_string', 0)
@@ -94,10 +95,12 @@ endif
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')  " guifg guibg gui cterm guisp
   function! s:HL(group, fg, bg, ...)
+    let l:fg = get(get(s:configuration.overwrite_groups, a:group, {}), 'fg', a:fg)
+    let l:bg = get(get(s:configuration.overwrite_groups, a:group, {}), 'bg', a:bg)
     let hl_string = [
           \ 'highlight', a:group,
-          \ 'guifg=' . a:fg[0],
-          \ 'guibg=' . a:bg[0],
+          \ 'guifg=' . l:fg[0],
+          \ 'guibg=' . l:bg[0],
           \ ]
     if a:0 >= 1
       if a:1 ==# 'undercurl'
@@ -118,10 +121,12 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')  " guifg guibg
   endfunction
 elseif s:t_Co >= 256  " ctermfg ctermbg cterm
   function! s:HL(group, fg, bg, ...)
+    let l:fg = get(get(s:configuration.overwrite_groups, a:group, {}), 'fg', a:fg)
+    let l:bg = get(get(s:configuration.overwrite_groups, a:group, {}), 'bg', a:bg)
     let hl_string = [
           \ 'highlight', a:group,
-          \ 'ctermfg=' . a:fg[1],
-          \ 'ctermbg=' . a:bg[1],
+          \ 'ctermfg=' . l:fg[1],
+          \ 'ctermbg=' . l:bg[1],
           \ ]
     if a:0 >= 1
       if a:1 ==# 'undercurl'
@@ -136,10 +141,12 @@ elseif s:t_Co >= 256  " ctermfg ctermbg cterm
   endfunction
 else  " ctermfg ctermbg cterm
   function! s:HL(group, fg, bg, ...)
+    let l:fg = get(get(s:configuration.overwrite_groups, a:group, {}), 'fg', a:fg)
+    let l:bg = get(get(s:configuration.overwrite_groups, a:group, {}), 'bg', a:bg)
     let hl_string = [
           \ 'highlight', a:group,
-          \ 'ctermfg=' . a:fg[2],
-          \ 'ctermbg=' . a:bg[2],
+          \ 'ctermfg=' . l:fg[2],
+          \ 'ctermbg=' . l:bg[2],
           \ ]
     if a:0 >= 1
       if a:1 ==# 'undercurl'


### PR DESCRIPTION
# Introduction

Looking through the implementation, one can see that it is possible to customize the `s:palette` by setting a `g:pinkmare_palette` variable. However, it does not appear to be possible to adjust individual highlight groups. For example, I never agreed with how tabs looked, but I am otherwise happy with the default color palette. That said, I created a local branch in which I hard-coded the modification.

This PR adds the ability to further configure the various highlight groups, similar in spirit to how one can configure the default palette. It works through a global configuration variable, and effectively hooks into the `s:HL` function.

# Changes

## Customizing highlight groups (bb534da9f5b95c137a25a377fbea7fd815ea8f94)

An additional `s:configuration.overwrite_groups` was added which looks for a `g:pinkmare_overwrite_groups` global configuration variable. It is a dictionary, where the keys indicate the highlight group to overwrite, and the value is another dictionary which may take the keys `fg` or `bg`, both of which take a list of values. The assumption is that the values are of the same structure as those already specified in `s:palette`.

To make this a non-intrusive feature addition, I have modified the `s:HL` functions. Instead of using the `a:fg` and `a:bg` variables directly, I now define intermediary variables. The goal is to first of all check if a key with the given `a:group` is found in the `s:configuration.overwrite_groups` dictionary, and if so retrieve the nested `bg` and `fg` keys. If they are not found, it will resort to using the provided `a:fg` or `a:bg` respectively.

## Use (default) palette for custom highlight groups (efa27fcff20ea7171a365417aba8656dbcb67639)

As explained in the respective commit, the `s:palette` is of course not visible to the outside. But in my case, I found that even a kind of `g:palette` or a sort of getter function was not available yet by the time I configure the `g:pinkmare_overwrite_groups` variable. The plugin was not loaded yet.

To make it possible to reliably re-use the existing palette (taking into account custom modifications through `g:pinkmare_palette`), I have refactored the palette definition into autoload functions. As a result, I have also removed the `s:configuration.palette` (because it was not needed anymore) and moved the logic into the autoload function.

- A new funtion `pinkmare#get_default_palette()` returns the default palette. This was previously defined directly as `s:palette`.
- However, an `extend()` was used to allow for the aforementioned customizations to the palette, which is reflected in the `pinkmare#get_palette()` function. It retrieves the default palette, and applies possible customizations.

Thanks to these autoloaded functions, it is now possible to reliably use the palette when definiting custom highlights for the groups.

# Example

Here is how to configure the highlight groups. Note that the `TabLine` group re-uses the palette; this avoids hard-coding the values, and as a result possibly miss out on updates to the colorscheme. Without the autoloaded function, I was not able to refer to the palette due to the plugin not being loaded yet.

Below is an equivalent vimscript example.

As you can see, the keys respectively define the highlight group as they are also found in `colors/pinkmare.vim`. The addition inside of `s:HL` now checks for these customizations. As you can see, `fg` and `bg` keys are both optional, if you don't provide either one, it will simply fall back to the *default highlight*.

```lua
vim.g.pinkmare_overwrite_groups = {
    ['@string'] = {
        fg = { '#FF38A2', '167', 'Red' },
        bg = { '#FAE8B6', '223', 'White' },
    },
    String = {
        bg = { '#87c095', '108', 'Cyan' },
    },
    TabLine = {
        bg = vim.fn['pinkmare#get_palette']().bg1,
    },
}
```

Here is an equivalent vimscript example (with different colors to be able to distringuish).

```vim
let g:pinkmare_overwrite_groups = {
    \     '@string' : {
    \         'fg' : [ '#FF38A2', '167', 'Red' ],
    \         'bg' : [ '#0AE8B6', '223', 'White' ],
    \     },
    \     'String' : {
    \         'bg' : [ '#87c005', '108', 'Cyan' ],
    \     },
    \     'TabLine' : {
    \         'bg' : pinkmare#get_palette()['bg1'],
    \     },
    \ }
```

# Additional comments

I am not too convinced `g:pinkmare_overwrite_groups` is a good variable name which is in-line with your naming scheme. I am absolutely open to renaming it!

For the rest, I am also happy to take further suggestions or changes, both regarding the refactor to an autoloaded function, and regarding to how I effectively *hook* into the highlight definition.

If you spot any problems, I will be happy to look into them! This is my first code contribution, so I am hoping everything is fine!

---

Also let me take the opportunity to thank you for this colorscheme! After spending many years on [everforest](https://github.com/sainnhe/everforest) ~~even back when it was still called forest-night~~, I had a hard time settling on a new colorscheme. Pinkmare instantly clicked and I have been using it happily for the past couple of years as well! Thank you for the work and thank you for the quite essential treesitter integration which came in at some point!